### PR TITLE
using the $var syntax is deprecated; use ${var} instead

### DIFF
--- a/scripts/build_lambdas.sh
+++ b/scripts/build_lambdas.sh
@@ -3,13 +3,13 @@
 temp_path=lambda/.temp/
 
 # Make a temp dir to build in 
-mkdir $temp_path
+mkdir ${temp_path}
 
 # Copy code to the temp path
-cp lambda/cats/* $temp_path
+cp lambda/cats/* ${temp_path}
 
 # Install requirements to temp path
-cd $temp_path
+cd ${temp_path}
 pip install -r requirements.txt -t .
 
 # Make a build directory and zip up the build package
@@ -18,4 +18,4 @@ zip -r ../../builds/cats.zip ./*
 
 # Remove the temparary build dir
 cd ../../
-rm -r $temp_path
+rm -r ${temp_path}


### PR DESCRIPTION
This syntax is deterministic across bash-like shells. [More information here.](
https://stackoverflow.com/questions/8748831/when-do-we-need-curly-braces-in-variables-using-bash)