### PR TITLE
Make sed region/account substitution work on OSX.

### DIFF
--- a/scripts/s3_sync.sh
+++ b/scripts/s3_sync.sh
@@ -40,7 +40,7 @@ then
   echo "These tools are expecting to be ran from the base of the SAM-Example repo."
   exit 1
 fi
-sed -i "s/<region>/${REGION}/g" docs/awscats.yml
-sed -i "s/<account_id>/${ACCOUNT_ID}/g" docs/awscats.yml
+sed -i '' "s/<region>/${REGION}/g" docs/awscats.yml
+sed -i '' "s/<account_id>/${ACCOUNT_ID}/g" docs/awscats.yml
 aws s3 sync ./builds/ s3://${BUCKET}/builds/ --profile ${PROFILE} --exclude *.git/* --exclude *.swp
 aws s3 sync ./docs/ s3://${BUCKET}/docs/ --profile ${PROFILE} --exclude *.git/* --exclude *.swp 

--- a/scripts/s3_sync.sh
+++ b/scripts/s3_sync.sh
@@ -40,7 +40,7 @@ then
   echo "These tools are expecting to be ran from the base of the SAM-Example repo."
   exit 1
 fi
-sed -i '' "s/<region>/${REGION}/g" docs/awscats.yml
-sed -i '' "s/<account_id>/${ACCOUNT_ID}/g" docs/awscats.yml
+sed -i.bak "s/<region>/${REGION}/g" docs/awscats.yml
+sed -i.bak "s/<account_id>/${ACCOUNT_ID}/g" docs/awscats.yml
 aws s3 sync ./builds/ s3://${BUCKET}/builds/ --profile ${PROFILE} --exclude *.git/* --exclude *.swp
 aws s3 sync ./docs/ s3://${BUCKET}/docs/ --profile ${PROFILE} --exclude *.git/* --exclude *.swp 


### PR DESCRIPTION
Sadly, `sed` on OSX **requires** an extension when using the -i switch. The quick fix is to specify an empty string.  Hopefully Linux doesn't care either way.

This is really fun project Derek - thanks for sharing it.  Next up, 'hotdog' versus 'not hotdog'!

-t